### PR TITLE
CS-4352-001 - Tomas Rohatynski - Require that command for GET:/Simulation/<command> is "check"

### DIFF
--- a/helper/api.py
+++ b/helper/api.py
@@ -25,6 +25,10 @@ def simulation(command):
       return "Invalid command", 400
 
   elif request.method == 'GET':
+    #Require that provided was 'check'
+    if command.lower() != 'check':
+      return "Invalid command", 400
+    
     #Return the current status of the simulation
     if completeEvent.is_set():
       return "Simulation is complete.", 200


### PR DESCRIPTION
Require that command for GET:/Simulation/<command> is "check" to match final project API specification on Blackboard